### PR TITLE
Improve developer test workflow

### DIFF
--- a/.hemtt/missions/0000_IEDD_NOTEBOOK_TEST.Stratis/mission.sqm
+++ b/.hemtt/missions/0000_IEDD_NOTEBOOK_TEST.Stratis/mission.sqm
@@ -1,0 +1,223 @@
+version=54;
+class EditorData
+{
+	moveGridStep=1;
+	angleGridStep=0.2617994;
+	scaleGridStep=1;
+	autoGroupingDist=10;
+	toggles=5;
+	class ItemIDProvider
+	{
+		nextID=4;
+	};
+	class Camera
+	{
+		pos[]={1913.8051,53.913181,5762.4653};
+		dir[]={-0.63605744,-0.74849755,-0.18761359};
+		up[]={-0.71791911,0.66313916,-0.21175961};
+		aside[]={-0.28291476,6.9077942e-008,0.95915174};
+	};
+};
+binarizationWanted=0;
+sourceName="0000_iedd_notebook_test";
+addons[]=
+{
+	"A3_Characters_F",
+	"ace_explosives",
+	"A3_Modules_F_Curator_Curator"
+};
+class AddonsMetaData
+{
+	class List
+	{
+		items=3;
+		class Item0
+		{
+			className="A3_Characters_F";
+			name="Arma 3 Alpha - Characters and Clothing";
+			author="Bohemia Interactive";
+			url="https://www.arma3.com";
+		};
+		class Item1
+		{
+			className="ace_explosives";
+			name="ACE3 - Explosives";
+			author="ACE-Team";
+			url="https://ace3.acemod.org/";
+		};
+		class Item2
+		{
+			className="A3_Modules_F_Curator";
+			name="Arma 3 Zeus Update - Scripted Modules";
+			author="Bohemia Interactive";
+			url="https://www.arma3.com";
+		};
+	};
+};
+randomSeed=3982459;
+class ScenarioData
+{
+	author="Richard Feynman";
+	briefing=0;
+	debriefing=0;
+	showCompass=0;
+	showGPS=0;
+	showHUD=0;
+	showMap=0;
+	showUAVFeed=0;
+	showWatch=0;
+	saving=0;
+	respawnDialog=0;
+	disabledAI=1;
+	joinUnassigned=0;
+	respawn=2;
+	respawnDelay=5;
+	class Header
+	{
+		gameType="Zeus";
+	};
+};
+class CustomAttributes
+{
+	class Category0
+	{
+		name="Multiplayer";
+		class Attribute0
+		{
+			property="RespawnTemplates";
+			expression="true";
+			class Value
+			{
+				class data
+				{
+					singleType="ARRAY";
+				};
+			};
+		};
+		nAttributes=1;
+	};
+};
+class Mission
+{
+	class Intel
+	{
+		timeOfChanges=1800.0002;
+		startWeather=0.30000001;
+		startWind=0.1;
+		startWaves=0.1;
+		forecastWeather=0.30000001;
+		forecastWind=0.1;
+		forecastWaves=0.1;
+		forecastLightnings=0.1;
+		wavesForced=1;
+		windForced=1;
+		year=2035;
+		month=7;
+		day=6;
+		hour=12;
+		minute=0;
+		startFogDecay=0.014;
+		forecastFogDecay=0.014;
+	};
+	class Entities
+	{
+		items=2;
+		class Item0
+		{
+			dataType="Group";
+			side="West";
+			class Entities
+			{
+				items=1;
+				class Item0
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1862.3934,5.5660334,5757.1006};
+					};
+					side="West";
+					flags=7;
+					class Attributes
+					{
+						isPlayer=1;
+					};
+					id=1;
+					type="B_soldier_exp_F";
+					atlOffset=4.7683716e-007;
+				};
+			};
+			class Attributes
+			{
+			};
+			id=0;
+			atlOffset=4.7683716e-007;
+		};
+		class Item1
+		{
+			dataType="Logic";
+			class PositionInfo
+			{
+				position[]={1876.1541,5.622716,5750.3892};
+			};
+			id=2;
+			type="ModuleCurator_F";
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="ModuleCurator_F_Owner";
+					expression="_this setVariable ['Owner',_value,true];";
+					class Value
+					{
+						class data
+						{
+							singleType="STRING";
+							value="#adminlogged";
+						};
+					};
+				};
+				class Attribute1
+				{
+					property="ModuleCurator_F_Forced";
+					expression="_this setVariable ['Forced',_value,true];";
+					class Value
+					{
+						class data
+						{
+							singleType="SCALAR";
+							value=0;
+						};
+					};
+				};
+				class Attribute2
+				{
+					property="ModuleCurator_F_Name";
+					expression="_this setVariable ['Name',_value,true];";
+					class Value
+					{
+						class data
+						{
+							singleType="STRING";
+							value="";
+						};
+					};
+				};
+				class Attribute3
+				{
+					property="ModuleCurator_F_Addons";
+					expression="_this setVariable ['Addons',_value,true];";
+					class Value
+					{
+						class data
+						{
+							singleType="SCALAR";
+							value=2;
+						};
+					};
+				};
+				nAttributes=4;
+			};
+		};
+	};
+};

--- a/.hemtt/project.toml
+++ b/.hemtt/project.toml
@@ -24,4 +24,6 @@ preset = "Hemtt"
 workshop = [
     "450814997", # CBA_A3
     "463939057", # ace
+    "1779063631", # Zeus Enhanced
+    "2018593688", # Zeus Enhanced - ACE Compatibility
 ]

--- a/.hemtt/project.toml
+++ b/.hemtt/project.toml
@@ -27,3 +27,4 @@ workshop = [
     "1779063631", # Zeus Enhanced
     "2018593688", # Zeus Enhanced - ACE Compatibility
 ]
+mission="0000_IEDD_NOTEBOOK_TEST.Stratis"

--- a/.hemtt/project.toml
+++ b/.hemtt/project.toml
@@ -20,7 +20,7 @@ exclude = [
 [hemtt.config]
 preset = "Hemtt"
 
-[hemtt.launch]
+[hemtt.launch.default]
 workshop = [
     "450814997", # CBA_A3
     "463939057", # ace


### PR DESCRIPTION
Hello,
I want to improve the developer test workflow by using hemtt.launch to launch into a prepared developer test mission in the Arma3 Eden Editor.
This removes the tedious tasks for each testbuild to start the Eden Editor, create a small test mission and start this mission.

The workflow for development is then:

1. Change code
2. In IEDD source directory execute: ` hemtt build; hemtt launch`
3. Arma3 and worksop Addons are started.
4. **Developer test map is automatically loaded in Eden Editor**

MR includes the following changes:

- Change hmtt.launch to hemtt.launch.default to remove hemtt WARN log message to use hemtt.launch.default.
- Add workshop dependencies to "Zeus Enhanced" and "Zeus Enhanced - ACE Compatibility" for easier ingame testing.
- Add 0000_IEDD_NOTEBOOK_TEST.Statis developer test mission.
- Developer test mission is added as hemtt.launch.default mission.

Please give me feedback and/or apply this Merge Request.