### PR TITLE
Add configureable boolean value to ignore wire cut order.

### DIFF
--- a/addons/ied/Stringtable.xml
+++ b/addons/ied/Stringtable.xml
@@ -435,7 +435,16 @@
 			<Key ID="STR_iedd_ied_FailExploseChance_Description">
 				<Original>% of activate IED after failed wire cut.</Original>
 				<English>% of activate IED after failed wire cut.</English>
-			</Key>						
+			</Key>
+			</Key>
+			<Key ID="STR_iedd_ied_WrongWireCutExplodeChance">
+				<Original>Chance to activate IED after cutting wrong wire</Original>
+				<English>Chance to activate IED after cutting wrong wire</English>
+			</Key>
+			<Key ID="STR_iedd_ied_WrongWireCutExplodeChance_Description">
+				<Original>% of activate IED after cutting wrong wire</Original>
+				<English>% of activate IED after cutting wrong wire</English>
+			</Key>
 			<Key ID="STR_iedd_ied_IsBlockedRange">
 				<Original>Just keep talking and nobody explodes-mode</Original>
 				<English>Just keep talking and nobody explodes-mode</English>

--- a/addons/ied/Stringtable.xml
+++ b/addons/ied/Stringtable.xml
@@ -437,13 +437,13 @@
 				<English>% of activate IED after failed wire cut.</English>
 			</Key>
 			</Key>
-			<Key ID="STR_iedd_ied_WrongWireCutExplodeChance">
-				<Original>Chance to activate IED after cutting wrong wire</Original>
-				<English>Chance to activate IED after cutting wrong wire</English>
+			<Key ID="STR_iedd_ied_IgnoreWireCutOrder">
+				<Original>Ignore wire cut order</Original>
+				<English>Ignore wire cut order</English>
 			</Key>
-			<Key ID="STR_iedd_ied_WrongWireCutExplodeChance_Description">
-				<Original>% of activate IED after cutting wrong wire</Original>
-				<English>% of activate IED after cutting wrong wire</English>
+			<Key ID="STR_iedd_ied_IgnoreWireCutOrder_Description">
+				<Original>IEDs do not explode on cutting the wrong wire.</Original>
+				<Original>IEDs do not explode on cutting the wrong wire.</Original>
 			</Key>
 			<Key ID="STR_iedd_ied_IsBlockedRange">
 				<Original>Just keep talking and nobody explodes-mode</Original>

--- a/addons/ied/functions/fnc_cutWire.sqf
+++ b/addons/ied/functions/fnc_cutWire.sqf
@@ -40,7 +40,10 @@ deleteVehicle _wire;
 				[QGVAR(defused), [_player, _bombObj]] call CBA_fnc_globalEvent;
 			};
 		} else {
-			[QGVAR(explosion), [_bombObj]] call CBA_fnc_serverEvent;
+			private _explodeChance = random 1;
+			if (_explodeChance < GVAR(wrongWireCutExplodeChance)) then {
+				[QGVAR(explosion), [_bombObj]] call CBA_fnc_serverEvent;
+			};
 		};
 	}, 
 	[_wire,_bombObj,_order,_player]

--- a/addons/ied/initSettings.inc.sqf
+++ b/addons/ied/initSettings.inc.sqf
@@ -107,12 +107,14 @@
 ] call CBA_fnc_addSetting;
 
 [
-    QGVAR(wrongWireCutExplodeChance),
-    "SLIDER",
-    [CSTRING(WrongWireCutExplodeChance),CSTRING(WrongWireCutExplodeChance_Description)],
+    QGVAR(ignoreWireCutOrder),
+    "CHECKBOX",
+    [CSTRING(IgnoreWireCutOrder),CSTRING(IgnoreWireCutOrder_Description)],
 	[localize "STR_iedd_main_Category_Main","IEDs"],
-    [0, 1, 1.0, 0, true],
-    1
+    false,
+    true,
+    {},
+    true // Needs mission restart
 ] call CBA_fnc_addSetting;
 
 [

--- a/addons/ied/initSettings.inc.sqf
+++ b/addons/ied/initSettings.inc.sqf
@@ -107,6 +107,15 @@
 ] call CBA_fnc_addSetting;
 
 [
+    QGVAR(wrongWireCutExplodeChance),
+    "SLIDER",
+    [CSTRING(WrongWireCutExplodeChance),CSTRING(WrongWireCutExplodeChance_Description)],
+	[localize "STR_iedd_main_Category_Main","IEDs"],
+    [0, 1, 1.0, 0, true],
+    1
+] call CBA_fnc_addSetting;
+
+[
     QGVAR(isBlockedRange),
     "CHECKBOX",	
     [CSTRING(IsBlockedRange),CSTRING(IsBlockedRange_Description)],


### PR DESCRIPTION
# Add configureable boolean value to ignore wire cut order.
Adds a config option for explode IED when cutting the wrong wire.

Default value is false, when cutting a wrong wire the IED explodes.
On value true, when cutting a wrong wire the IED does not explode.
IED activation is then only by proximity oder speed/movement.

# Reasons to accept this Pull Request
- You can use the IEDD Notebook models for IEDs without using the Notebook by completely removing the wire cut order. **A great advantage of IEDD Notebook is: It enables each player to spot IEDs visually.**
- Helps with introducing IEDD Notebook to a community as you can always make disarming IEDs simpler for new players.
- When you do not have enough EOD personal, a single EOD person can remove IEDs faster and reduce the waiting time for other players.
- You can simulate poorly build IEDs.