### PR TITLE
Adjust more ACE carry positions for IED objects

### DIFF
--- a/addons/ied/iedbucket.hpp
+++ b/addons/ied/iedbucket.hpp
@@ -35,7 +35,7 @@ class GVAR(Bucket):Land_PlasticBucket_01_closed_F {
     ace_dragging_dragPosition[] = {0, 1, 0};
     ace_dragging_dragDirection = 0;
     ace_dragging_canCarry = 1;
-    ace_dragging_carryPosition[] = {0, 0.6, 0};
+    ace_dragging_carryPosition[] = {0, 0.7, 0};
     ace_dragging_carryDirection = 0;
     ace_cargo_size = 2;
     ace_cargo_canLoad = 1;

--- a/addons/ied/iedcan.hpp
+++ b/addons/ied/iedcan.hpp
@@ -25,7 +25,7 @@ class GVAR(CanisterPlastic):Land_CanisterPlastic_F {
     ace_dragging_dragPosition[] = {0, 1, 0};
     ace_dragging_dragDirection = 0;
     ace_dragging_canCarry = 1;
-    ace_dragging_carryPosition[] = {0, 0.6, 0};
+    ace_dragging_carryPosition[] = {0, 0.9, 0};
     ace_dragging_carryDirection = 0;
     ace_cargo_size = 2;
     ace_cargo_canLoad = 1;

--- a/addons/ied/iedmetal.hpp
+++ b/addons/ied/iedmetal.hpp
@@ -26,7 +26,7 @@ class GVAR(Metal):Land_GarbageBarrel_01_F {
     ace_dragging_dragPosition[] = {0, 1, 0};
     ace_dragging_dragDirection = 0;
     ace_dragging_canCarry = 1;
-    ace_dragging_carryPosition[] = {0, 0.6, 0};
+    ace_dragging_carryPosition[] = {0, 0.9, 0};
     ace_dragging_carryDirection = 0;
     ace_cargo_size = 2;
     ace_cargo_canLoad = 1;


### PR DESCRIPTION
Updated the ace_dragging_carryPosition values for Bucket, CanisterPlastic, and Metal IED objects to improve their carry alignment. This change should enhance the realism and usability when carrying these objects in-game.