### PR TITLE
Setting - New: Disable the Vanilla Mine Detector Sidepanel Radar

### DIFF
--- a/addons/ied/XEH_PREP.hpp
+++ b/addons/ied/XEH_PREP.hpp
@@ -15,6 +15,7 @@ PREP(defuseAction);
 PREP(deleted);
 PREP(detachAction);
 PREP(disarmAction);
+PREP(disableMineDetectorDisplay);
 PREP(dud);
 PREP(dudWires);
 PREP(explosion);

--- a/addons/ied/XEH_postInit.sqf
+++ b/addons/ied/XEH_postInit.sqf
@@ -149,6 +149,11 @@ if (isServer) then {
 
 if (!hasInterface) exitWith {};
 
+ACE_player addEventHandler ["Respawn", {
+    params ["_unit", ""];
+    [QGVAR(disableMineDetectorDisplay), _unit] call FUNC(disableMineDetectorDisplay);
+}];
+
 ["unit", {[ACE_player] call FUNC(addItems)},true] call CBA_fnc_addPlayerEventHandler;
 
 [QGVAR(sound), {
@@ -157,3 +162,4 @@ if (!hasInterface) exitWith {};
 }] call CBA_fnc_addEventHandler;
 
 GVAR(fail) = false;
+

--- a/addons/ied/functions/fnc_disableMineDetectorDisplay.sqf
+++ b/addons/ied/functions/fnc_disableMineDetectorDisplay.sqf
@@ -1,0 +1,25 @@
+#include "..\script_component.hpp"
+/*
+ * Author: Zorn
+ * Adds Function to enable/disable the side panel Mine Detector Radar
+ *
+ * Arguments:
+ * 0: Disabled Radar <BOOL>
+ * 1: Unit (optional - Default: ACE_player)<OBJECT>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [_bombObj] call iedd_ied_fnc_disarmAction;
+ *
+ * Public: No
+ */
+
+params [
+    ["_disabled", true, [true]],
+    ["_unit", ACE_player, [objNull]]
+ ];
+
+_unit enableInfoPanelComponent ["left", "MineDetectorDisplay", !_disabled];
+_unit enableInfoPanelComponent ["right", "MineDetectorDisplay", !_disabled];

--- a/addons/ied/functions/fnc_disableMineDetectorDisplay.sqf
+++ b/addons/ied/functions/fnc_disableMineDetectorDisplay.sqf
@@ -16,6 +16,8 @@
  * Public: No
  */
 
+if (!hasInterface) exitWith {};
+
 params [
     ["_disabled", true, [true]],
     ["_unit", ACE_player, [objNull]]

--- a/addons/ied/functions/fnc_disableMineDetectorDisplay.sqf
+++ b/addons/ied/functions/fnc_disableMineDetectorDisplay.sqf
@@ -11,17 +11,20 @@
  * None
  *
  * Example:
- * [_bombObj] call iedd_ied_fnc_disarmAction;
+ * [true, ACE_player] call iedd_ied_fnc_disableMineDetectorDisplay;
  *
  * Public: No
  */
-
-if (!hasInterface) exitWith {};
 
 params [
     ["_disabled", true, [true]],
     ["_unit", ACE_player, [objNull]]
  ];
 
+TRACE_1(QGVAR(disableMineDetectorDisplay),_disabled);
+
+if (!hasInterface) exitWith {
+    TRACE_1(QGVAR(disableMineDetectorDisplay),"No interface available");
+};
 _unit enableInfoPanelComponent ["left", "MineDetectorDisplay", !_disabled];
 _unit enableInfoPanelComponent ["right", "MineDetectorDisplay", !_disabled];

--- a/addons/ied/initSettings.inc.sqf
+++ b/addons/ied/initSettings.inc.sqf
@@ -169,6 +169,17 @@
 ] call CBA_fnc_addSetting;
 
 [
+    QGVAR(disableMineDetectorDisplay),
+    "CHECKBOX",
+    [LSTRING(DisableMineDetectorDisplay), LSTRING(DisableMineDetectorDisplay_Description)],
+    [localize "STR_iedd_main_Category_Main","Items"],
+    true,
+    true,
+    FUNC(disableMineDetectorDisplay),
+    false // Needs mission restart
+] call CBA_fnc_addSetting;
+
+[
     QGVAR(isEod),
     "CHECKBOX",
     [LSTRING(IsEod), LSTRING(IsEod_Description)],

--- a/addons/ied/stringtable.xml
+++ b/addons/ied/stringtable.xml
@@ -162,6 +162,14 @@
                 <Original>Adds Defusal Kit to all players with EOD/Explosive Specialist trait on mission start.</Original>
                 <English>Adds Defusal Kit to all players with EOD/Explosive Specialist trait on mission start.</English>
             </Key>
+            <Key ID="STR_iedd_ied_DisableMineDetectorDisplay">
+                <Original>Disable MineDetector Display</Original>
+                <English>Disable MineDetector Display</English>
+            </Key>
+            <Key ID="STR_iedd_ied_DisableMineDetectorDisplay_Description">
+                <Original>Disables the Side Panel Mine Detector Radar which are used by Vanilla Mine Detector.</Original>
+                <English>Disables the Side Panel Mine Detector Radar which are used by Vanilla Mine Detector.</English>
+            </Key>
             <Key ID="STR_iedd_ied_AddNotebook">
                 <Original>Add IEDD Notebook to EODs/Explosive specialists</Original>
                 <English>Add IEDD Notebook to EODs/Explosive specialists</English>


### PR DESCRIPTION
Introduces a new setting to disable the side panel Mine Detector Radar for players. Adds supporting function, event handler on respawn, and localization strings for the new option.